### PR TITLE
add proper XML namespace support for feature images in RSS feed #8

### DIFF
--- a/includes/actions-filters.php
+++ b/includes/actions-filters.php
@@ -54,7 +54,16 @@ add_action( 'wp_enqueue_scripts', 'sc_styles' );
 
 
 /**
- * Add featured image to RSS feed
+ * Add the media namespace to the RSS feed header
+ */
+function sc_add_media_namespace() {
+	echo 'xmlns:media="http://search.yahoo.com/mrss/"';
+}
+add_action( 'rss2_ns', 'sc_add_media_namespace' );
+
+
+/**
+ * Add featured image data to the RSS feed
  */
 function sc_rss_featured_image() {
 	global $post;


### PR DESCRIPTION
Resolves #8 

This PR adds the necessary XML namespace for supporting featured images in the blog RSS feed.

@cklosowski This properly modified the feed locally for me. It's also in the [XML on staging](http://staging.easydigitaldownloads.com/blog/feed). Once live, Joe will have to give the final confirmation that it's working for him while configuring Mailchimp.