### PR TITLE
issue/17 - Add EDD SL filter for upgrade pricing #17

### DIFF
--- a/includes/actions-filters.php
+++ b/includes/actions-filters.php
@@ -42,46 +42,6 @@ function sc_rss_featured_image() {
 add_filter( 'rss2_item', 'sc_rss_featured_image' );
 
 
-/**
- * Set the price that customers pay prior to March 1, 2021
- *
- * @param $price float The current item price
- * @param $download_id int Download product ID
- * @param $options array the cart item options
- *
- * @return float
- */
-function sc_edd_sl_grandfather( $price, $download_id, $options ) {
 
 
-	if ( ! empty( $options['license_id'] ) && empty( $options['upgrade_id'] ) ) {
 
-		// Only existing license keys get grandfathered
-		$license = edd_software_licensing()->get_license( $options['license_id'] );
-
-		if ( $license && $license->date_created < '2021-03-01 00:00:00' ) {
-
-			switch ( $license->download_id ) {
-
-				case 20 :
-
-					$price = 89;
-					break;
-
-				case 19 :
-
-					$price = 49;
-					break;
-
-				case 18 :
-
-					$price = 29;
-					break;
-
-			}
-		}
-	}
-
-	return $price;
-}
-add_filter( 'edd_cart_item_price', 'sc_edd_sl_grandfather', 10, 3 );

--- a/includes/integrations/easy-digital-downloads/software-licensing.php
+++ b/includes/integrations/easy-digital-downloads/software-licensing.php
@@ -1,0 +1,51 @@
+<?php // EDD Software Licensing functions
+
+/**
+ * Set the price that customers pay prior to March 1, 2021
+ *
+ * @param $price float The current item price
+ * @param $download_id int Download product ID
+ * @param $options array the cart item options
+ *
+ * @return float
+ */
+function sc_edd_sl_grandfather( $price, $download_id, $options ) {
+
+
+	if ( ! empty( $options['license_id'] ) && empty( $options['upgrade_id'] ) ) {
+
+		// Only existing license keys get grandfathered
+		$license = edd_software_licensing()->get_license( $options['license_id'] );
+
+		if ( $license && $license->date_created < '2021-03-01 00:00:00' ) {
+
+			switch ( $license->download_id ) {
+
+				case 20 :
+
+					$price = 89;
+					break;
+
+				case 19 :
+
+					$price = 49;
+					break;
+
+				case 18 :
+
+					$price = 29;
+					break;
+
+			}
+		}
+	}
+
+	return $price;
+}
+add_filter( 'edd_cart_item_price', 'sc_edd_sl_grandfather', 10, 3 );
+
+
+/**
+ * Use previous price paid (instead or current price) as the license upgrade old price
+ */
+add_filter( 'edd_sl_use_current_price_proration', '__return_false' );

--- a/includes/integrations/gravity-forms/help-scout-add-on.php
+++ b/includes/integrations/gravity-forms/help-scout-add-on.php
@@ -1,10 +1,15 @@
-<?php
+<?php // Gravity Forms Help Scout Add-on functions
 
 /**
  * Send a pushover notification when the Gravity Forms Help Scout addon is not authenticated.
  *
+ * @param $feed
+ * @param $entry
+ * @param $form
+ * @param $addon
  */
 function sc_helpscout_authentication_notification( $feed, $entry, $form, $addon ) {
+
 	// Only run this code if there is a problem with Help Scout API authentication.
 	if ( ! $addon->is_authenticated() && function_exists( 'ckpn_send_notification' ) ) {
 
@@ -19,6 +24,7 @@ function sc_helpscout_authentication_notification( $feed, $entry, $form, $addon 
 
 		// Find the users who can view_shop_reports and have a user key.
 		foreach ( $users as $user_id => $user_key ) {
+
 			if ( ! user_can( $user_id, $alert_capability ) ) {
 				continue;
 			}

--- a/sc-custom-functions.php
+++ b/sc-custom-functions.php
@@ -17,6 +17,7 @@
  */
 define( 'SC_PLUGIN_DIR', dirname( __FILE__ ) );
 define( 'SC_PLUGIN_INCLUDES', SC_PLUGIN_DIR . '/includes/' );
+define( 'SC_PLUGIN_INTEGRATIONS', SC_PLUGIN_INCLUDES . 'integrations/' );
 $sc_theme = wp_get_theme();
 define( 'SC_THEME_VERSION', $sc_theme->get( 'Version' ) );
 
@@ -41,7 +42,10 @@ class SC_Custom_Functions {
 
 		// General functions
 		include( SC_PLUGIN_INCLUDES . 'actions-filters.php' );
-		include( SC_PLUGIN_INCLUDES . '3rd-party-plugins.php' );
+
+		// Integrations
+		include( SC_PLUGIN_INTEGRATIONS . 'easy-digital-downloads/software-licensing.php' );
+		include( SC_PLUGIN_INTEGRATIONS . 'gravity-forms/help-scout-add-on.php' );
 
 		// Custom Post Type functions
 		include( SC_PLUGIN_INCLUDES . 'post-types/post-types.php' );


### PR DESCRIPTION
See #17 

That issue is already resolved, actually. But it's there that we found an SL bug which has been fixed in SL `release/3.7.1` branch. With that fix in place, a filter can be used here to base license upgrades off of the previous license price a customer paid, rather than the current price of the download they're upgrading from.

While implementing this, I did a slight plugin refactor to keep integration code organized.